### PR TITLE
Workflow support

### DIFF
--- a/AddQueue.ps1
+++ b/AddQueue.ps1
@@ -97,6 +97,8 @@ function Add-RabbitMQQueue
     {
         $Credentials = NormaliseCredentials
         $cnt = 0
+        # Add support for projects using workflows 
+        Add-Type -AssemblyName System.Web
     }
     Process
     {


### PR DESCRIPTION
Fixed error:
Invoke-RestMethod : Cannot process argument transformation on parameter 'Uri'. Cannot convert value "http://:15672/api/queues//" to type "System.Uri". Error: "URI        
inválido: não foi possível analisar o nome do anfitrião."
At monit:10 char:10
+
    + CategoryInfo          : InvalidData: (:) [Invoke-RestMethod], ParameterBindin...mationException
    + FullyQualifiedErrorId : ParameterArgumentTransformationError,Invoke-RestMethod
    + PSComputerName        : [localhost]

When using workflows for add queue